### PR TITLE
Update License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Lythium
+Copyright (c) 2021 Lythium4848 (https://github.com/lythium4848)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The license lacked a true definition of whom the copyright holder was.